### PR TITLE
Possible problems found by static analysis of code

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -860,7 +860,10 @@ hash_rehash (Hash_table *table, size_t candidate)
 		  struct hash_entry *new_entry = allocate_entry (new_table);
 
 		  if (new_entry == NULL)
-		    return false;
+		    {
+		      hash_free (new_table);
+		      return false;
+		    }
 
 		  new_entry->data = data;
 		  new_entry->next = new_bucket->next;

--- a/src/html.c
+++ b/src/html.c
@@ -435,7 +435,10 @@ init_ucs2_html (RECODE_STEP step,
     if (cursor->flags & mask
 	&& (!request->diacritics_only || cursor->code > 128))
       if (!hash_insert (table, cursor))
-	return false;
+	{
+	  hash_free (table);
+	  return false;
+	}
 
   step->step_type = RECODE_UCS2_TO_STRING;
   step->step_table = table;
@@ -616,7 +619,10 @@ init_html_ucs2 (RECODE_STEP step,
     if (cursor->flags & mask
 	&& (!request->diacritics_only || cursor->code > 128))
       if (!hash_insert (table, cursor))
-	return false;
+	{
+	  hash_free (table);
+	  return false;
+	}
 
   step->step_type = RECODE_STRING_TO_UCS2;
   step->step_table = table;

--- a/src/mixed.c
+++ b/src/mixed.c
@@ -61,7 +61,7 @@ open_mixed (struct mixed *mixed, RECODE_TASK task)
 	   !task->output.file)
     {
       recode_perror (NULL, "fopen (%s)", task->output.name);
-      if (*(task->input.name))
+      if (task->input.file != stdin)
 	fclose (task->input.file);
       return false;
     }

--- a/src/recode.c
+++ b/src/recode.c
@@ -206,6 +206,8 @@ complete_pairs (RECODE_OUTER outer, RECODE_STEP step,
 
   memset (left_flag, 0, 256);
   memset (right_flag, 0, 256);
+  memset (left_table, 0, 256);
+  memset (right_table, 0, 256);
   table_error = false;
 
   /* Establish known data.  */

--- a/src/request.c
+++ b/src/request.c
@@ -765,7 +765,10 @@ scan_options (RECODE_REQUEST request)
       scan_identifier (request);
       ALLOC (copy, strlen (request->scanned_string) + 1, char);
       if (!copy)
-	break;			/* FIXME: should interrupt decoding */
+	{
+	  free (new);
+	  break;		/* FIXME: should interrupt decoding */
+	}
       strcpy (copy, request->scanned_string);
 
       new_->option = copy;


### PR DESCRIPTION
Hello,

we analyzed the recode-3.6 code with Coverity.
Coverity is commercial enterprise level tool for
static analysis (analysis based only on compiling of sources,
not based on running of binary) of the code.

As a result I have 3 tiny commits that should fix some possible problems.
There's a respective part of the error log in each commit comment.

With regards,
Jiri Popelka,
Red Hat, inc.
