### PR TITLE
Allow to override man-page date

### DIFF
--- a/doc/help2man
+++ b/doc/help2man
@@ -233,7 +233,7 @@ my ($help_text, $version_text) = map {
 	    $_, $ARGV[0]
 } $help_option, $version_option;
 
-my $date = strftime "%B %Y", localtime;
+my $date = strftime "%B %Y", gmtime($ENV{SOURCE_DATE_EPOCH} || time);
 (my $program = $ARGV[0]) =~ s!.*/!!;
 my $package = $program;
 my $version;


### PR DESCRIPTION
to make package build reproducible.

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.